### PR TITLE
remove c9 project settings which are still tracked by git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 node_modules
-.c9/*
+/.c9/


### PR DESCRIPTION
The .c9/ directory still shows up in git. This should be the new .gitignore, but also need to run: git rm --cached .c9/ when first committing.

See http://stackoverflow.com/questions/26345488/git-continues-to-push-a-c9-folder-despite-it-being-in-gitignore